### PR TITLE
Tell users when a config fails opening vs processing

### DIFF
--- a/invalid/syntax.js
+++ b/invalid/syntax.js
@@ -1,0 +1,2 @@
+/*global fjdskfsklvner_sytax_error*/
+fjdskfsklvner_sytax_error();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "spandx.config.js"
     ],
     "scripts": {
-        "test": "jasmine spec/spandx/spandxSpec.js",
+        "test": "jasmine spec/spandx/*.js",
         "start": "node app/spandx.js",
         "dev": "nodemon spandx.js",
         "debug": "node-debug spandx.js",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
             "prettier --write",
             "git add"
         ],
-        "spec/spandx/*[sS]pec.js": [
-            "npm test"
-        ],
-        "{app,spec}/**/*.{js,json}": [
-            "git add"
-        ],
         "examples/**/*.{js,json}": [
             "prettier --write",
             "git add"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
     "lint-staged": {
         "{app,spec}/**/*.{js,json}": [
             "prettier --write",
-            "npm test",
+            "git add"
+        ],
+        "spec/spandx/*[sS]pec.js": [
+            "npm test"
+        ],
+        "{app,spec}/**/*.{js,json}": [
             "git add"
         ],
         "examples/**/*.{js,json}": [

--- a/spec/helpers/configs/invalid/syntax.js
+++ b/spec/helpers/configs/invalid/syntax.js
@@ -1,2 +1,3 @@
 /*global fjdskfsklvner_sytax_error*/
+// prettier-ignore
 fjdskfsklvner_sytax_error();

--- a/spec/spandx/configSpec.js
+++ b/spec/spandx/configSpec.js
@@ -20,7 +20,7 @@ describe("fromFile", () => {
 
     it("should throw ConfigProcessError on syntax error file", () => {
         return config
-            .fromFile("../invalid/syntax.js")
+            .fromFile("../spec/helpers/configs/invalid/syntax.js")
             .then(shouldNotResolve)
             .catch(e => {
                 catchSpecificError(e, "ConfigProcessError");

--- a/spec/spandx/configSpec.js
+++ b/spec/spandx/configSpec.js
@@ -1,0 +1,38 @@
+/*global describe, it, require, expect*/
+
+const config = require("../../app/config.js");
+
+const shouldNotResolve = () => {
+    throw new Error("This promise should have been rejected!");
+};
+
+const catchSpecificError = (e, name) => {
+    if (e.name === name) {
+        return;
+    }
+    throw new Error(`Expected to see a ${name} but got ${e.toString()}`);
+};
+
+describe("fromFile", () => {
+    it("should load the default config", () => {
+        return config.fromFile("../spandx.config.js");
+    });
+
+    it("should throw ConfigProcessError on syntax error file", () => {
+        return config
+            .fromFile("../invalid/syntax.js")
+            .then(shouldNotResolve)
+            .catch(e => {
+                catchSpecificError(e, "ConfigProcessError");
+            });
+    });
+
+    it("should throw ConfigOpenError on missing file", () => {
+        return config
+            .fromFile("/tmp/foo/nonexist/blah/test.js")
+            .then(shouldNotResolve)
+            .catch(e => {
+                catchSpecificError(e, "ConfigOpenError");
+            });
+    });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,11 +1,7 @@
 {
-  "spec_dir": "spec",
-  "spec_files": [
-    "**/*[sS]pec.js"
-  ],
-  "helpers": [
-    "helpers/**/*.js"
-  ],
-  "stopSpecOnExpectationFailure": false,
-  "random": false
+    "spec_dir": "spec",
+    "spec_files": ["**/*[sS]pec.js"],
+    "helpers": ["helpers/reporter.js"],
+    "stopSpecOnExpectationFailure": false,
+    "random": false
 }


### PR DESCRIPTION
Configs are JS not JSON, sometimes they happen to fail and when they do Spandx says "couldn't find it, or couldn't access it". This isn't true and can confuse (I kept checking perms, path etc :D).

When a processing error occurs Spandx should tell the user, and show the error.

```
Jasmine started

  fromFile
    ✓ should load the default config (0.011 sec)
    ✓ should throw ConfigProcessError on syntax error file (0.001 sec)
    ✓ should throw ConfigOpenError on missing file (0.001 sec)

Executed 3 of 3 specs SUCCESS in 0.02 sec
```