### PR TITLE
don't include startPath in route logging

### DIFF
--- a/app/spandx.js
+++ b/app/spandx.js
@@ -123,9 +123,12 @@ async function init(confIn) {
                     return conf.spandxUrl
                         .map(
                             url =>
-                                `  ${c.fg.l.blue}${url.replace(/\/$/, "")}${
-                                    c.end
-                                }${c.fg.l.green}${route[0]}${
+                                `  ${c.fg.l.blue}${url
+                                    .replace(/\/$/, "")
+                                    .replace(
+                                        new RegExp(`${conf.startPath}$`),
+                                        ""
+                                    )}${c.end}${c.fg.l.green}${route[0]}${
                                     c.e
                                 } will be routed to ${c.fg.l.blue}${route[1]
                                     .host.default || route[1].host}${c.e}${

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
             "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
             }
         },
         "@samverschueren/stream-to-observable": {
@@ -30,7 +30,7 @@
             "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
             "dev": true,
             "requires": {
-                "any-observable": "0.3.0"
+                "any-observable": "^0.3.0"
             }
         },
         "@schibstedpl/circuit-breaker-js": {
@@ -55,7 +55,7 @@
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "requires": {
-                "mime-types": "2.1.18",
+                "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
             },
             "dependencies": {
@@ -69,7 +69,7 @@
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
                     "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
                     "requires": {
-                        "mime-db": "1.33.0"
+                        "mime-db": "~1.33.0"
                     }
                 }
             }
@@ -86,7 +86,7 @@
             "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3"
+                "acorn": "^5.0.0"
             }
         },
         "after": {
@@ -99,8 +99,8 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
             "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
             }
         },
         "ansi-align": {
@@ -109,7 +109,7 @@
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -130,8 +130,8 @@
                     "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -140,7 +140,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -162,7 +162,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "^1.9.0"
             }
         },
         "any-observable": {
@@ -176,8 +176,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -190,7 +190,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "micromatch": {
@@ -198,19 +198,19 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 }
             }
@@ -227,7 +227,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -243,7 +243,7 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -340,8 +340,8 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
             "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
             "requires": {
-                "follow-redirects": "1.5.0",
-                "is-buffer": "1.1.6"
+                "follow-redirects": "^1.2.5",
+                "is-buffer": "^1.1.5"
             }
         },
         "backo2": {
@@ -360,13 +360,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -375,7 +375,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -384,7 +384,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -393,7 +393,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -402,9 +402,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -442,7 +442,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "better-assert": {
@@ -468,7 +468,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "boxen": {
@@ -477,13 +477,13 @@
             "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
             "dev": true,
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -498,7 +498,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "camelcase": {
@@ -513,9 +513,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -536,8 +536,8 @@
                     "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -546,7 +546,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -555,7 +555,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -565,7 +565,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -574,9 +574,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-process-hrtime": {
@@ -599,16 +599,16 @@
             "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.4.tgz",
             "integrity": "sha512-qfXv8vQA/Dctub2v44v/vPuvfC4XNd6bn+W5vWZVuhuy6w91lPsdY6qhalT2s2PjnJ3FR6kWq5wkTQgN26eKzA==",
             "requires": {
-                "browser-sync-ui": "1.0.1",
+                "browser-sync-ui": "v1.0.1",
                 "bs-recipes": "1.3.4",
                 "chokidar": "1.7.0",
                 "connect": "3.5.0",
-                "connect-history-api-fallback": "1.5.0",
-                "dev-ip": "1.0.1",
+                "connect-history-api-fallback": "^1.5.0",
+                "dev-ip": "^1.0.1",
                 "easy-extender": "2.3.2",
                 "eazy-logger": "3.0.2",
-                "etag": "1.8.1",
-                "fresh": "0.5.2",
+                "etag": "^1.8.1",
+                "fresh": "^0.5.2",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
                 "immutable": "3.8.2",
@@ -617,7 +617,7 @@
                 "opn": "4.0.2",
                 "portscanner": "2.1.1",
                 "qs": "6.2.3",
-                "raw-body": "2.3.3",
+                "raw-body": "^2.3.2",
                 "resp-modifier": "6.0.2",
                 "rx": "4.1.0",
                 "serve-index": "1.8.0",
@@ -638,9 +638,9 @@
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "connect": {
@@ -648,9 +648,9 @@
                     "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
                     "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
                     "requires": {
-                        "debug": "2.2.0",
+                        "debug": "~2.2.0",
                         "finalhandler": "0.5.0",
-                        "parseurl": "1.3.2",
+                        "parseurl": "~1.3.1",
                         "utils-merge": "1.0.0"
                     }
                 },
@@ -667,11 +667,11 @@
                     "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                     "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
                     "requires": {
-                        "debug": "2.2.0",
-                        "escape-html": "1.0.3",
-                        "on-finished": "2.3.0",
-                        "statuses": "1.3.1",
-                        "unpipe": "1.0.0"
+                        "debug": "~2.2.0",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "statuses": "~1.3.0",
+                        "unpipe": "~1.0.0"
                     }
                 },
                 "http-proxy": {
@@ -679,8 +679,8 @@
                     "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
                     "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
                     "requires": {
-                        "eventemitter3": "1.2.0",
-                        "requires-port": "1.0.0"
+                        "eventemitter3": "1.x.x",
+                        "requires-port": "1.x.x"
                     }
                 },
                 "is-extglob": {
@@ -693,7 +693,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "micromatch": {
@@ -701,19 +701,19 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ms": {
@@ -726,8 +726,8 @@
                     "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
                     "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
                     "requires": {
-                        "object-assign": "4.1.1",
-                        "pinkie-promise": "2.0.1"
+                        "object-assign": "^4.0.1",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "os-locale": {
@@ -735,7 +735,7 @@
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                     "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                     "requires": {
-                        "lcid": "1.0.0"
+                        "lcid": "^1.0.0"
                     }
                 },
                 "qs": {
@@ -753,20 +753,20 @@
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
                     "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "window-size": "0.2.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "4.2.1"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "window-size": "^0.2.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.1.0"
                     }
                 },
                 "yargs-parser": {
@@ -774,7 +774,7 @@
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -785,11 +785,11 @@
             "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "1.5.0",
-                "immutable": "3.8.2",
+                "connect-history-api-fallback": "^1.1.0",
+                "immutable": "^3.7.6",
                 "server-destroy": "1.0.1",
                 "socket.io-client": "2.0.4",
-                "stream-throttle": "0.1.3"
+                "stream-throttle": "^0.1.3"
             }
         },
         "bs-recipes": {
@@ -819,15 +819,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -871,9 +871,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "chokidar": {
@@ -881,15 +881,15 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.2.4",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -902,7 +902,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -919,10 +919,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -931,7 +931,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "isobject": {
@@ -954,7 +954,7 @@
             "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
             "dev": true,
             "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
             }
         },
         "cli-spinners": {
@@ -970,7 +970,7 @@
             "dev": true,
             "requires": {
                 "slice-ansi": "0.0.4",
-                "string-width": "1.0.2"
+                "string-width": "^1.0.1"
             }
         },
         "cliui": {
@@ -978,9 +978,9 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -993,8 +993,8 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -1002,7 +1002,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -1028,8 +1028,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -1038,7 +1038,7 @@
             "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -1058,7 +1058,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -1092,12 +1092,12 @@
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "dev": true,
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.3.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "connect": {
@@ -1107,7 +1107,7 @@
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
-                "parseurl": "1.3.2",
+                "parseurl": "~1.3.2",
                 "utils-merge": "1.0.1"
             },
             "dependencies": {
@@ -1117,12 +1117,12 @@
                     "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "1.0.2",
-                        "escape-html": "1.0.3",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
-                        "statuses": "1.3.1",
-                        "unpipe": "1.0.0"
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
+                        "statuses": "~1.3.1",
+                        "unpipe": "~1.0.0"
                     }
                 },
                 "utils-merge": {
@@ -1165,9 +1165,9 @@
             "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
             "dev": true,
             "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.11.0",
-                "parse-json": "4.0.0"
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.9.0",
+                "parse-json": "^4.0.0"
             }
         },
         "create-error-class": {
@@ -1176,7 +1176,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -1184,9 +1184,9 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -1194,7 +1194,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "crypto-random-string": {
@@ -1215,7 +1215,7 @@
             "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.2"
+                "cssom": "0.3.x"
             }
         },
         "dashdash": {
@@ -1223,7 +1223,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1239,9 +1239,9 @@
             "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
             "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.1"
+                "abab": "^1.0.4",
+                "whatwg-mimetype": "^2.0.0",
+                "whatwg-url": "^6.4.0"
             }
         },
         "date-fns": {
@@ -1293,8 +1293,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1303,7 +1303,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1312,7 +1312,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1321,9 +1321,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -1372,7 +1372,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "4.0.2"
+                "webidl-conversions": "^4.0.2"
             }
         },
         "dot-prop": {
@@ -1381,7 +1381,7 @@
             "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer": {
@@ -1401,7 +1401,7 @@
             "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
             "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
             "requires": {
-                "lodash": "3.10.1"
+                "lodash": "^3.10.1"
             },
             "dependencies": {
                 "lodash": {
@@ -1416,7 +1416,7 @@
             "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
             "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
             "requires": {
-                "tfunk": "3.1.0"
+                "tfunk": "^3.0.1"
             }
         },
         "ecc-jsbn": {
@@ -1425,7 +1425,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "ecstatic": {
@@ -1434,10 +1434,10 @@
             "integrity": "sha512-Goilx/2cfU9vvfQjgtNgc2VmJAD8CasQ6rZDqCd2u4Hsyd/qFET6nBf60jiHodevR3nl3IGzNKtrzPXWP88utQ==",
             "dev": true,
             "requires": {
-                "he": "1.1.1",
-                "mime": "1.6.0",
-                "minimist": "1.2.0",
-                "url-join": "2.0.5"
+                "he": "^1.1.1",
+                "mime": "^1.4.1",
+                "minimist": "^1.1.0",
+                "url-join": "^2.0.2"
             },
             "dependencies": {
                 "mime": {
@@ -1475,7 +1475,7 @@
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "dev": true,
             "requires": {
-                "iconv-lite": "0.4.23"
+                "iconv-lite": "~0.4.13"
             }
         },
         "engine.io": {
@@ -1483,13 +1483,13 @@
             "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
             "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "3.1.0",
-                "engine.io-parser": "2.1.2",
-                "uws": "9.14.0",
-                "ws": "3.3.3"
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.0",
+                "uws": "~9.14.0",
+                "ws": "~3.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -1505,9 +1505,9 @@
                     "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
                     "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
                     "requires": {
-                        "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "ultron": "1.1.1"
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
                     }
                 }
             }
@@ -1519,14 +1519,14 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "3.1.0",
-                "engine.io-parser": "2.1.2",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.1",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "3.3.3",
-                "xmlhttprequest-ssl": "1.5.5",
+                "ws": "~3.3.1",
+                "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             },
             "dependencies": {
@@ -1543,9 +1543,9 @@
                     "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
                     "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
                     "requires": {
-                        "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "ultron": "1.1.1"
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
                     }
                 }
             }
@@ -1556,10 +1556,10 @@
             "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
             "requires": {
                 "after": "0.8.2",
-                "arraybuffer.slice": "0.0.7",
+                "arraybuffer.slice": "~0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.4",
-                "has-binary2": "1.0.3"
+                "has-binary2": "~1.0.2"
             }
         },
         "error-ex": {
@@ -1567,7 +1567,7 @@
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "escape-html": {
@@ -1586,11 +1586,11 @@
             "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
             "dev": true,
             "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.6.1"
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -1637,13 +1637,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "eventemitter3": {
@@ -1656,13 +1656,13 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "exit-hook": {
@@ -1676,7 +1676,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -1684,7 +1684,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "expect": {
@@ -1693,12 +1693,12 @@
             "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "jest-diff": "22.4.3",
-                "jest-get-type": "22.4.3",
-                "jest-matcher-utils": "22.4.3",
-                "jest-message-util": "22.4.3",
-                "jest-regex-util": "22.4.3"
+                "ansi-styles": "^3.2.0",
+                "jest-diff": "^22.4.3",
+                "jest-get-type": "^22.4.3",
+                "jest-matcher-utils": "^22.4.3",
+                "jest-message-util": "^22.4.3",
+                "jest-regex-util": "^22.4.3"
             }
         },
         "extend": {
@@ -1712,8 +1712,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1722,7 +1722,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1732,7 +1732,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1771,8 +1771,8 @@
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
             }
         },
         "filename-regex": {
@@ -1785,11 +1785,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "finalhandler": {
@@ -1798,12 +1798,12 @@
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.4.0",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.4.0",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "statuses": {
@@ -1824,7 +1824,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "follow-redirects": {
@@ -1832,7 +1832,7 @@
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
             "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
             "requires": {
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1855,7 +1855,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -1868,9 +1868,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -1879,7 +1879,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -1893,10 +1893,10 @@
             "integrity": "sha1-3I28yH8T9y4NU8wqsm80WOUnTkY=",
             "dev": true,
             "requires": {
-                "form-data": "2.3.2",
-                "joi": "13.3.0",
-                "lodash": "4.17.10",
-                "node-fetch": "1.7.3"
+                "form-data": "^2.2.0",
+                "joi": "^13.0.0",
+                "lodash": "^4.11.1",
+                "node-fetch": "^1.5.2"
             },
             "dependencies": {
                 "combined-stream": {
@@ -1905,7 +1905,7 @@
                     "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                     "dev": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "form-data": {
@@ -1914,9 +1914,9 @@
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.17"
+                        "mime-types": "^2.1.12"
                     }
                 }
             }
@@ -1932,9 +1932,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
             "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "3.0.1",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -1949,8 +1949,8 @@
             "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.10.0"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1972,8 +1972,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -1984,7 +1984,7 @@
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2038,7 +2038,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -2051,14 +2051,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -2066,12 +2066,12 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -2084,7 +2084,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -2092,7 +2092,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -2100,8 +2100,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2117,7 +2117,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -2129,7 +2129,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2140,8 +2140,8 @@
                     "version": "2.2.4",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -2149,7 +2149,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -2169,9 +2169,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2179,16 +2179,16 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -2196,8 +2196,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -2210,8 +2210,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -2219,10 +2219,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2238,7 +2238,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2256,8 +2256,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2275,10 +2275,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2293,13 +2293,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -2307,7 +2307,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2343,9 +2343,9 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -2353,14 +2353,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2373,13 +2373,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2392,7 +2392,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2432,7 +2432,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2448,12 +2448,12 @@
             "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2461,8 +2461,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2475,7 +2475,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2485,7 +2485,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2498,7 +2498,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2509,7 +2509,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "good-guy-http": {
@@ -2537,17 +2537,17 @@
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.1",
-                "safe-buffer": "5.1.1",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -2565,8 +2565,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
             }
         },
         "has-ansi": {
@@ -2574,7 +2574,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2616,9 +2616,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -2635,8 +2635,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2645,7 +2645,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2654,7 +2654,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2665,7 +2665,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2675,10 +2675,10 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -2703,7 +2703,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "1.0.3"
+                "whatwg-encoding": "^1.0.1"
             }
         },
         "http-errors": {
@@ -2711,10 +2711,10 @@
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.5.0"
+                "statuses": ">= 1.4.0 < 2"
             },
             "dependencies": {
                 "statuses": {
@@ -2729,9 +2729,9 @@
             "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
             "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "requires": {
-                "eventemitter3": "3.1.0",
-                "follow-redirects": "1.5.0",
-                "requires-port": "1.0.0"
+                "eventemitter3": "^3.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
             },
             "dependencies": {
                 "eventemitter3": {
@@ -2748,13 +2748,13 @@
             "dev": true,
             "requires": {
                 "colors": "1.0.3",
-                "corser": "2.0.1",
-                "ecstatic": "3.2.0",
-                "http-proxy": "1.17.0",
-                "opener": "1.4.3",
-                "optimist": "0.6.1",
-                "portfinder": "1.0.13",
-                "union": "0.4.6"
+                "corser": "~2.0.0",
+                "ecstatic": "^3.0.0",
+                "http-proxy": "^1.8.1",
+                "opener": "~1.4.0",
+                "optimist": "0.6.x",
+                "portfinder": "^1.0.13",
+                "union": "~0.4.3"
             },
             "dependencies": {
                 "colors": {
@@ -2770,9 +2770,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "husky": {
@@ -2781,9 +2781,9 @@
             "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
             "dev": true,
             "requires": {
-                "is-ci": "1.1.0",
-                "normalize-path": "1.0.0",
-                "strip-indent": "2.0.0"
+                "is-ci": "^1.0.10",
+                "normalize-path": "^1.0.0",
+                "strip-indent": "^2.0.0"
             },
             "dependencies": {
                 "normalize-path": {
@@ -2799,7 +2799,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ignore-by-default": {
@@ -2831,7 +2831,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "indexof": {
@@ -2845,8 +2845,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -2871,7 +2871,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-arrayish": {
@@ -2884,7 +2884,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -2897,7 +2897,7 @@
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-ci": {
@@ -2906,7 +2906,7 @@
             "integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
             "dev": true,
             "requires": {
-                "ci-info": "1.1.2"
+                "ci-info": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -2915,7 +2915,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-descriptor": {
@@ -2924,9 +2924,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2953,7 +2953,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -2973,7 +2973,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -2981,7 +2981,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-generator-fn": {
@@ -2996,7 +2996,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-installed-globally": {
@@ -3005,8 +3005,8 @@
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "dev": true,
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-npm": {
@@ -3020,7 +3020,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-number-like": {
@@ -3028,7 +3028,7 @@
             "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
             "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
             "requires": {
-                "lodash.isfinite": "3.3.2"
+                "lodash.isfinite": "^3.3.2"
             }
         },
         "is-obj": {
@@ -3043,7 +3043,7 @@
             "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
             "dev": true,
             "requires": {
-                "symbol-observable": "1.2.0"
+                "symbol-observable": "^1.1.0"
             }
         },
         "is-odd": {
@@ -3052,7 +3052,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -3069,7 +3069,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -3078,7 +3078,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -3161,7 +3161,7 @@
             "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "2.x.x"
             },
             "dependencies": {
                 "punycode": {
@@ -3196,8 +3196,8 @@
             "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "jasmine-core": "3.1.0"
+                "glob": "^7.0.6",
+                "jasmine-core": "~3.1.0"
             }
         },
         "jasmine-core": {
@@ -3221,17 +3221,17 @@
             "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "glob": "7.1.2",
-                "jest-environment-jsdom": "22.4.3",
-                "jest-environment-node": "22.4.3",
-                "jest-get-type": "22.4.3",
-                "jest-jasmine2": "22.4.4",
-                "jest-regex-util": "22.4.3",
-                "jest-resolve": "22.4.3",
-                "jest-util": "22.4.3",
-                "jest-validate": "22.4.4",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "glob": "^7.1.1",
+                "jest-environment-jsdom": "^22.4.1",
+                "jest-environment-node": "^22.4.1",
+                "jest-get-type": "^22.1.0",
+                "jest-jasmine2": "^22.4.4",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve": "^22.4.2",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "pretty-format": "^22.4.0"
             }
         },
         "jest-diff": {
@@ -3240,10 +3240,10 @@
             "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "diff": "3.5.0",
-                "jest-get-type": "22.4.3",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "diff": "^3.2.0",
+                "jest-get-type": "^22.4.3",
+                "pretty-format": "^22.4.3"
             }
         },
         "jest-environment-jsdom": {
@@ -3252,9 +3252,9 @@
             "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
             "dev": true,
             "requires": {
-                "jest-mock": "22.4.3",
-                "jest-util": "22.4.3",
-                "jsdom": "11.11.0"
+                "jest-mock": "^22.4.3",
+                "jest-util": "^22.4.3",
+                "jsdom": "^11.5.1"
             }
         },
         "jest-environment-node": {
@@ -3263,8 +3263,8 @@
             "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
             "dev": true,
             "requires": {
-                "jest-mock": "22.4.3",
-                "jest-util": "22.4.3"
+                "jest-mock": "^22.4.3",
+                "jest-util": "^22.4.3"
             }
         },
         "jest-get-type": {
@@ -3279,17 +3279,17 @@
             "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "co": "4.6.0",
-                "expect": "22.4.3",
-                "graceful-fs": "4.1.11",
-                "is-generator-fn": "1.0.0",
-                "jest-diff": "22.4.3",
-                "jest-matcher-utils": "22.4.3",
-                "jest-message-util": "22.4.3",
-                "jest-snapshot": "22.4.3",
-                "jest-util": "22.4.3",
-                "source-map-support": "0.5.6"
+                "chalk": "^2.0.1",
+                "co": "^4.6.0",
+                "expect": "^22.4.0",
+                "graceful-fs": "^4.1.11",
+                "is-generator-fn": "^1.0.0",
+                "jest-diff": "^22.4.0",
+                "jest-matcher-utils": "^22.4.0",
+                "jest-message-util": "^22.4.0",
+                "jest-snapshot": "^22.4.0",
+                "jest-util": "^22.4.1",
+                "source-map-support": "^0.5.0"
             }
         },
         "jest-matcher-utils": {
@@ -3298,9 +3298,9 @@
             "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-get-type": "22.4.3",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "jest-get-type": "^22.4.3",
+                "pretty-format": "^22.4.3"
             }
         },
         "jest-message-util": {
@@ -3309,11 +3309,11 @@
             "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.49",
-                "chalk": "2.4.1",
-                "micromatch": "2.3.11",
-                "slash": "1.0.0",
-                "stack-utils": "1.0.1"
+                "@babel/code-frame": "^7.0.0-beta.35",
+                "chalk": "^2.0.1",
+                "micromatch": "^2.3.11",
+                "slash": "^1.0.0",
+                "stack-utils": "^1.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -3328,7 +3328,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "micromatch": {
@@ -3337,19 +3337,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 }
             }
@@ -3372,8 +3372,8 @@
             "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
             "dev": true,
             "requires": {
-                "browser-resolve": "1.11.2",
-                "chalk": "2.4.1"
+                "browser-resolve": "^1.11.2",
+                "chalk": "^2.0.1"
             }
         },
         "jest-snapshot": {
@@ -3382,12 +3382,12 @@
             "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-diff": "22.4.3",
-                "jest-matcher-utils": "22.4.3",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "jest-diff": "^22.4.3",
+                "jest-matcher-utils": "^22.4.3",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^22.4.3"
             }
         },
         "jest-util": {
@@ -3396,13 +3396,13 @@
             "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
             "dev": true,
             "requires": {
-                "callsites": "2.0.0",
-                "chalk": "2.4.1",
-                "graceful-fs": "4.1.11",
-                "is-ci": "1.1.0",
-                "jest-message-util": "22.4.3",
-                "mkdirp": "0.5.1",
-                "source-map": "0.6.1"
+                "callsites": "^2.0.0",
+                "chalk": "^2.0.1",
+                "graceful-fs": "^4.1.11",
+                "is-ci": "^1.0.10",
+                "jest-message-util": "^22.4.3",
+                "mkdirp": "^0.5.1",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -3419,11 +3419,11 @@
             "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-config": "22.4.4",
-                "jest-get-type": "22.4.3",
-                "leven": "2.1.0",
-                "pretty-format": "22.4.3"
+                "chalk": "^2.0.1",
+                "jest-config": "^22.4.4",
+                "jest-get-type": "^22.1.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^22.4.0"
             }
         },
         "joi": {
@@ -3432,9 +3432,9 @@
             "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
             "dev": true,
             "requires": {
-                "hoek": "5.0.3",
-                "isemail": "3.1.2",
-                "topo": "3.0.0"
+                "hoek": "5.x.x",
+                "isemail": "3.x.x",
+                "topo": "3.x.x"
             },
             "dependencies": {
                 "hoek": {
@@ -3457,8 +3457,8 @@
             "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -3473,32 +3473,32 @@
             "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
             "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.5.3",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "cssom": "0.3.2",
-                "cssstyle": "0.3.1",
-                "data-urls": "1.0.0",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.1",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.3.0",
-                "nwsapi": "2.0.1",
+                "abab": "^1.0.4",
+                "acorn": "^5.3.0",
+                "acorn-globals": "^4.1.0",
+                "array-equal": "^1.0.0",
+                "cssom": ">= 0.3.2 < 0.4.0",
+                "cssstyle": ">= 0.3.1 < 0.4.0",
+                "data-urls": "^1.0.0",
+                "domexception": "^1.0.0",
+                "escodegen": "^1.9.0",
+                "html-encoding-sniffer": "^1.0.2",
+                "left-pad": "^1.2.0",
+                "nwsapi": "^2.0.0",
                 "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.87.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-mimetype": "2.1.0",
-                "whatwg-url": "6.4.1",
-                "ws": "4.1.0",
-                "xml-name-validator": "3.0.0"
+                "pn": "^1.1.0",
+                "request": "^2.83.0",
+                "request-promise-native": "^1.0.5",
+                "sax": "^1.2.4",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.3.3",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.3",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^6.4.1",
+                "ws": "^4.0.0",
+                "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -3507,10 +3507,10 @@
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "assert-plus": {
@@ -3531,9 +3531,9 @@
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.17"
+                        "mime-types": "^2.1.12"
                     },
                     "dependencies": {
                         "combined-stream": {
@@ -3542,7 +3542,7 @@
                             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                             "dev": true,
                             "requires": {
-                                "delayed-stream": "1.0.0"
+                                "delayed-stream": "~1.0.0"
                             }
                         }
                     }
@@ -3559,8 +3559,8 @@
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "http-signature": {
@@ -3569,9 +3569,9 @@
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "performance-now": {
@@ -3586,26 +3586,26 @@
                     "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.0.3",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.1",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
                     }
                 }
             }
@@ -3632,7 +3632,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -3645,7 +3645,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
             "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -3676,7 +3676,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "latest-version": {
@@ -3685,7 +3685,7 @@
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "dev": true,
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             }
         },
         "lcid": {
@@ -3693,7 +3693,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "left-pad": {
@@ -3714,8 +3714,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "limiter": {
@@ -3729,29 +3729,29 @@
             "integrity": "sha512-IEh09VAFuFYZh376kh61Dwg1Nifs511868okujVqrESDkTqVZ3/2rZ1kFXEf0DtUHPc2HtyemJ03W6ISqRYdLQ==",
             "dev": true,
             "requires": {
-                "app-root-path": "2.0.1",
-                "chalk": "2.4.1",
-                "commander": "2.15.1",
-                "cosmiconfig": "5.0.5",
-                "debug": "3.1.0",
-                "dedent": "0.7.0",
-                "execa": "0.9.0",
-                "find-parent-dir": "0.3.0",
-                "is-glob": "4.0.0",
-                "is-windows": "1.0.2",
-                "jest-validate": "22.4.4",
-                "listr": "0.14.1",
-                "lodash": "4.17.10",
-                "log-symbols": "2.2.0",
-                "micromatch": "3.1.10",
-                "npm-which": "3.0.1",
-                "p-map": "1.2.0",
-                "path-is-inside": "1.0.2",
-                "pify": "3.0.0",
-                "please-upgrade-node": "3.0.2",
+                "app-root-path": "^2.0.1",
+                "chalk": "^2.3.1",
+                "commander": "^2.14.1",
+                "cosmiconfig": "^5.0.2",
+                "debug": "^3.1.0",
+                "dedent": "^0.7.0",
+                "execa": "^0.9.0",
+                "find-parent-dir": "^0.3.0",
+                "is-glob": "^4.0.0",
+                "is-windows": "^1.0.2",
+                "jest-validate": "^22.4.0",
+                "listr": "^0.14.1",
+                "lodash": "^4.17.5",
+                "log-symbols": "^2.2.0",
+                "micromatch": "^3.1.8",
+                "npm-which": "^3.0.1",
+                "p-map": "^1.1.1",
+                "path-is-inside": "^1.0.2",
+                "pify": "^3.0.0",
+                "please-upgrade-node": "^3.0.2",
                 "staged-git-files": "1.1.1",
-                "string-argv": "0.0.2",
-                "stringify-object": "3.2.2"
+                "string-argv": "^0.0.2",
+                "stringify-object": "^3.2.2"
             },
             "dependencies": {
                 "debug": {
@@ -3769,13 +3769,13 @@
                     "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 }
             }
@@ -3786,22 +3786,22 @@
             "integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
             "dev": true,
             "requires": {
-                "@samverschueren/stream-to-observable": "0.3.0",
-                "cli-truncate": "0.2.1",
-                "figures": "1.7.0",
-                "indent-string": "2.1.0",
-                "is-observable": "1.1.0",
-                "is-promise": "2.1.0",
-                "is-stream": "1.1.0",
-                "listr-silent-renderer": "1.1.1",
-                "listr-update-renderer": "0.4.0",
-                "listr-verbose-renderer": "0.4.1",
-                "log-symbols": "1.0.2",
-                "log-update": "1.0.2",
-                "ora": "0.2.3",
-                "p-map": "1.2.0",
-                "rxjs": "6.2.0",
-                "strip-ansi": "3.0.1"
+                "@samverschueren/stream-to-observable": "^0.3.0",
+                "cli-truncate": "^0.2.1",
+                "figures": "^1.7.0",
+                "indent-string": "^2.1.0",
+                "is-observable": "^1.1.0",
+                "is-promise": "^2.1.0",
+                "is-stream": "^1.1.0",
+                "listr-silent-renderer": "^1.1.1",
+                "listr-update-renderer": "^0.4.0",
+                "listr-verbose-renderer": "^0.4.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^1.0.2",
+                "ora": "^0.2.3",
+                "p-map": "^1.1.1",
+                "rxjs": "^6.1.0",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3816,11 +3816,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "log-symbols": {
@@ -3829,7 +3829,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                     }
                 },
                 "supports-color": {
@@ -3852,14 +3852,14 @@
             "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-truncate": "0.2.1",
-                "elegant-spinner": "1.0.1",
-                "figures": "1.7.0",
-                "indent-string": "3.2.0",
-                "log-symbols": "1.0.2",
-                "log-update": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "elegant-spinner": "^1.0.1",
+                "figures": "^1.7.0",
+                "indent-string": "^3.0.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^1.0.2",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3874,11 +3874,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "indent-string": {
@@ -3893,7 +3893,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                     }
                 },
                 "supports-color": {
@@ -3910,10 +3910,10 @@
             "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "date-fns": "1.29.0",
-                "figures": "1.7.0"
+                "chalk": "^1.1.3",
+                "cli-cursor": "^1.0.2",
+                "date-fns": "^1.27.2",
+                "figures": "^1.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3928,11 +3928,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -3948,11 +3948,11 @@
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "parse-json": {
@@ -3960,7 +3960,7 @@
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "requires": {
-                        "error-ex": "1.3.1"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "pify": {
@@ -3991,9 +3991,9 @@
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "debug": {
@@ -4009,7 +4009,7 @@
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                     "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                     "requires": {
-                        "lcid": "1.0.0"
+                        "lcid": "^1.0.0"
                     }
                 },
                 "which-module": {
@@ -4022,19 +4022,19 @@
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "4.2.1"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.2.0"
                     }
                 },
                 "yargs-parser": {
@@ -4042,7 +4042,7 @@
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -4052,8 +4052,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -4078,7 +4078,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "log-update": {
@@ -4087,8 +4087,8 @@
             "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "1.4.0",
-                "cli-cursor": "1.0.2"
+                "ansi-escapes": "^1.0.0",
+                "cli-cursor": "^1.0.2"
             }
         },
         "lowercase-keys": {
@@ -4102,8 +4102,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
             "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "make-dir": {
@@ -4112,7 +4112,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -4141,7 +4141,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "math-random": {
@@ -4154,7 +4154,7 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "micromatch": {
@@ -4163,19 +4163,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4196,16 +4196,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4214,7 +4214,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4225,13 +4225,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4240,7 +4240,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -4249,7 +4249,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -4258,7 +4258,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4267,7 +4267,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4278,7 +4278,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4287,7 +4287,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4298,9 +4298,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -4317,14 +4317,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4333,7 +4333,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -4342,7 +4342,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4353,10 +4353,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4365,7 +4365,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4376,7 +4376,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4385,7 +4385,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4394,9 +4394,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -4405,7 +4405,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4414,7 +4414,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4443,7 +4443,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "mimic-fn": {
@@ -4456,7 +4456,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -4471,8 +4471,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4481,7 +4481,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4520,18 +4520,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4571,8 +4571,8 @@
             "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
             "dev": true,
             "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
             }
         },
         "nodemon": {
@@ -4581,16 +4581,16 @@
             "integrity": "sha512-FG2mWJU1Y58a9ktgMJ/RZpsiPz3b7ge77t/okZHEa4NbrlXGKZ8s1A6Q+C7+JPXohAfcPALRwvxcAn8S874pmw==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.3",
-                "debug": "3.1.0",
-                "ignore-by-default": "1.0.1",
-                "minimatch": "3.0.4",
-                "pstree.remy": "1.1.0",
-                "semver": "5.5.0",
-                "supports-color": "5.4.0",
-                "touch": "3.1.0",
-                "undefsafe": "2.0.2",
-                "update-notifier": "2.5.0"
+                "chokidar": "^2.0.2",
+                "debug": "^3.1.0",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "pstree.remy": "^1.1.0",
+                "semver": "^5.5.0",
+                "supports-color": "^5.2.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.2",
+                "update-notifier": "^2.3.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -4599,8 +4599,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -4621,16 +4621,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4639,7 +4639,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4650,18 +4650,18 @@
                     "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.4",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.1.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.0"
                     }
                 },
                 "debug": {
@@ -4679,13 +4679,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "debug": {
@@ -4703,7 +4703,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -4712,7 +4712,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -4721,7 +4721,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4730,7 +4730,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4741,7 +4741,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4750,7 +4750,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4761,9 +4761,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -4780,14 +4780,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4796,7 +4796,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -4805,7 +4805,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4816,10 +4816,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4828,7 +4828,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4839,8 +4839,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -4849,7 +4849,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -4866,7 +4866,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4875,7 +4875,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4884,9 +4884,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -4901,7 +4901,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -4910,7 +4910,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4919,7 +4919,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4942,19 +4942,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "semver": {
@@ -4969,7 +4969,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -4989,7 +4989,7 @@
             "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
             "dev": true,
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -4997,10 +4997,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.4.1",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -5008,7 +5008,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "npm-path": {
@@ -5017,7 +5017,7 @@
             "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
             "dev": true,
             "requires": {
-                "which": "1.3.0"
+                "which": "^1.2.10"
             }
         },
         "npm-run-path": {
@@ -5025,7 +5025,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npm-which": {
@@ -5034,9 +5034,9 @@
             "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
             "dev": true,
             "requires": {
-                "commander": "2.15.1",
-                "npm-path": "2.0.4",
-                "which": "1.3.0"
+                "commander": "^2.9.0",
+                "npm-path": "^2.0.2",
+                "which": "^1.2.10"
             }
         },
         "number-is-nan": {
@@ -5071,9 +5071,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -5082,7 +5082,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -5098,7 +5098,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -5114,8 +5114,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -5124,7 +5124,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -5149,7 +5149,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -5175,7 +5175,7 @@
             "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
             "dev": true,
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {
@@ -5184,8 +5184,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -5202,12 +5202,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             },
             "dependencies": {
                 "wordwrap": {
@@ -5224,10 +5224,10 @@
             "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-spinners": "0.1.2",
-                "object-assign": "4.1.1"
+                "chalk": "^1.1.1",
+                "cli-cursor": "^1.0.2",
+                "cli-spinners": "^0.1.2",
+                "object-assign": "^4.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5242,11 +5242,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -5262,9 +5262,9 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
             }
         },
         "p-finally": {
@@ -5277,7 +5277,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -5285,7 +5285,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-map": {
@@ -5305,10 +5305,10 @@
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "dev": true,
             "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.2",
-                "registry-url": "3.1.0",
-                "semver": "5.4.1"
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "parse-glob": {
@@ -5316,10 +5316,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -5332,7 +5332,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -5343,8 +5343,8 @@
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1",
-                "json-parse-better-errors": "1.0.2"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parse5": {
@@ -5358,7 +5358,7 @@
             "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseuri": {
@@ -5366,7 +5366,7 @@
             "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseurl": {
@@ -5412,9 +5412,9 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5430,7 +5430,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "performance-now": {
@@ -5454,7 +5454,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "please-upgrade-node": {
@@ -5463,7 +5463,7 @@
             "integrity": "sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
             "dev": true,
             "requires": {
-                "semver-compare": "1.0.0"
+                "semver-compare": "^1.0.0"
             }
         },
         "pn": {
@@ -5478,9 +5478,9 @@
             "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             }
         },
         "portscanner": {
@@ -5489,7 +5489,7 @@
             "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
             "requires": {
                 "async": "1.5.2",
-                "is-number-like": "1.0.8"
+                "is-number-like": "^1.0.3"
             }
         },
         "porty": {
@@ -5532,8 +5532,8 @@
             "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0",
-                "ansi-styles": "3.2.1"
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
             }
         },
         "print-colors": {
@@ -5551,7 +5551,7 @@
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
             "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "ps-tree": {
@@ -5560,7 +5560,7 @@
             "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4"
+                "event-stream": "~3.3.0"
             }
         },
         "pseudomap": {
@@ -5574,7 +5574,7 @@
             "integrity": "sha1-8q8nJlvT5bMrv8wQ6AusVbp4aIs=",
             "dev": true,
             "requires": {
-                "ps-tree": "1.1.0"
+                "ps-tree": "^1.1.0"
             }
         },
         "punycode": {
@@ -5593,9 +5593,9 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -5632,10 +5632,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "read-pkg": {
@@ -5643,9 +5643,9 @@
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -5653,8 +5653,8 @@
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -5662,8 +5662,8 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-exists": {
@@ -5671,7 +5671,7 @@
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 }
             }
@@ -5681,13 +5681,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
             "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -5702,10 +5702,10 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.3",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "regex-cache": {
@@ -5713,7 +5713,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -5722,8 +5722,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "registry-auth-token": {
@@ -5732,8 +5732,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.8",
-                "safe-buffer": "5.1.1"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -5742,7 +5742,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "1.2.8"
+                "rc": "^1.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -5766,7 +5766,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "request": {
@@ -5774,28 +5774,28 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.6",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
             },
             "dependencies": {
                 "qs": {
@@ -5811,7 +5811,7 @@
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.13.1"
             }
         },
         "request-promise-native": {
@@ -5821,8 +5821,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
             }
         },
         "require-directory": {
@@ -5857,8 +5857,8 @@
             "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
             "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
             "requires": {
-                "debug": "2.6.9",
-                "minimatch": "3.0.4"
+                "debug": "^2.2.0",
+                "minimatch": "^3.0.2"
             }
         },
         "restore-cursor": {
@@ -5867,8 +5867,8 @@
             "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
             "dev": true,
             "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
             }
         },
         "ret": {
@@ -5888,7 +5888,7 @@
             "integrity": "sha512-qBzf5uu6eOKiCZuAE0SgZ0/Qp+l54oeVxFfC2t+mJ2SFI6IB8gmMdJHs5DUMu5kqifqcCtsKS2XHjhZu6RKvAw==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.2"
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -5902,7 +5902,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -5933,7 +5933,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "5.4.1"
+                "semver": "^5.0.3"
             }
         },
         "serve-index": {
@@ -5941,13 +5941,13 @@
             "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
             "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.3",
                 "batch": "0.5.3",
-                "debug": "2.2.0",
-                "escape-html": "1.0.3",
-                "http-errors": "1.5.1",
-                "mime-types": "2.1.17",
-                "parseurl": "1.3.2"
+                "debug": "~2.2.0",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.5.0",
+                "mime-types": "~2.1.11",
+                "parseurl": "~1.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -5965,7 +5965,7 @@
                     "requires": {
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.2",
-                        "statuses": "1.3.1"
+                        "statuses": ">= 1.3.1 < 2"
                     }
                 },
                 "ms": {
@@ -5985,9 +5985,9 @@
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.2"
             },
             "dependencies": {
@@ -5996,10 +5996,10 @@
                     "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
                     "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
                     "requires": {
-                        "depd": "1.1.2",
+                        "depd": "~1.1.2",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.1.0",
-                        "statuses": "1.4.0"
+                        "statuses": ">= 1.4.0 < 2"
                     }
                 },
                 "mime": {
@@ -6013,18 +6013,18 @@
                     "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
                     "requires": {
                         "debug": "2.6.9",
-                        "depd": "1.1.2",
-                        "destroy": "1.0.4",
-                        "encodeurl": "1.0.2",
-                        "escape-html": "1.0.3",
-                        "etag": "1.8.1",
+                        "depd": "~1.1.2",
+                        "destroy": "~1.0.4",
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
                         "fresh": "0.5.2",
-                        "http-errors": "1.6.3",
+                        "http-errors": "~1.6.2",
                         "mime": "1.4.1",
                         "ms": "2.0.0",
-                        "on-finished": "2.3.0",
-                        "range-parser": "1.2.0",
-                        "statuses": "1.4.0"
+                        "on-finished": "~2.3.0",
+                        "range-parser": "~1.2.0",
+                        "statuses": "~1.4.0"
                     }
                 },
                 "setprototypeof": {
@@ -6060,10 +6060,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6072,7 +6072,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6087,7 +6087,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -6118,14 +6118,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6134,7 +6134,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -6143,7 +6143,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6154,9 +6154,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -6165,7 +6165,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6174,7 +6174,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -6183,7 +6183,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -6192,9 +6192,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -6217,7 +6217,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
@@ -6225,7 +6225,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "socket.io": {
@@ -6233,11 +6233,11 @@
             "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
             "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
             "requires": {
-                "debug": "2.6.9",
-                "engine.io": "3.1.5",
-                "socket.io-adapter": "1.1.1",
+                "debug": "~2.6.6",
+                "engine.io": "~3.1.0",
+                "socket.io-adapter": "~1.1.0",
                 "socket.io-client": "2.0.4",
-                "socket.io-parser": "3.1.3"
+                "socket.io-parser": "~3.1.1"
             }
         },
         "socket.io-adapter": {
@@ -6254,14 +6254,14 @@
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "2.6.9",
-                "engine.io-client": "3.1.6",
+                "debug": "~2.6.4",
+                "engine.io-client": "~3.1.0",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "3.1.3",
+                "socket.io-parser": "~3.1.1",
                 "to-array": "0.1.4"
             }
         },
@@ -6271,8 +6271,8 @@
             "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "3.1.0",
-                "has-binary2": "1.0.3",
+                "debug": "~3.1.0",
+                "has-binary2": "~1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -6303,11 +6303,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.1",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -6316,8 +6316,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.0",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6339,8 +6339,8 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -6353,8 +6353,8 @@
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -6368,7 +6368,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -6377,7 +6377,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -6390,14 +6390,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6425,8 +6425,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6435,7 +6435,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -6456,7 +6456,7 @@
             "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
             "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
             "requires": {
-                "emitter-component": "1.1.1"
+                "emitter-component": "^1.1.1"
             }
         },
         "stream-combiner": {
@@ -6465,7 +6465,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-throttle": {
@@ -6473,8 +6473,8 @@
             "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
             "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
             "requires": {
-                "commander": "2.15.1",
-                "limiter": "1.1.3"
+                "commander": "^2.2.0",
+                "limiter": "^1.0.5"
             }
         },
         "string-argv": {
@@ -6488,9 +6488,9 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -6498,7 +6498,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringify-object": {
@@ -6507,9 +6507,9 @@
             "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
             "dev": true,
             "requires": {
-                "get-own-enumerable-property-symbols": "2.0.1",
-                "is-obj": "1.0.1",
-                "is-regexp": "1.0.0"
+                "get-own-enumerable-property-symbols": "^2.0.1",
+                "is-obj": "^1.0.1",
+                "is-regexp": "^1.0.0"
             }
         },
         "stringstream": {
@@ -6522,7 +6522,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6537,7 +6537,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-eof": {
@@ -6563,7 +6563,7 @@
             "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "symbol-observable": {
@@ -6584,7 +6584,7 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
         },
         "tfunk": {
@@ -6592,8 +6592,8 @@
             "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
             "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
             "requires": {
-                "chalk": "1.1.3",
-                "object-path": "0.9.2"
+                "chalk": "^1.1.1",
+                "object-path": "^0.9.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6606,11 +6606,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -6643,7 +6643,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -6652,10 +6652,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -6664,8 +6664,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -6674,7 +6674,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -6685,7 +6685,7 @@
             "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
             "dev": true,
             "requires": {
-                "hoek": "5.0.3"
+                "hoek": "5.x.x"
             },
             "dependencies": {
                 "hoek": {
@@ -6702,7 +6702,7 @@
             "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
             "dev": true,
             "requires": {
-                "nopt": "1.0.10"
+                "nopt": "~1.0.10"
             }
         },
         "tough-cookie": {
@@ -6710,7 +6710,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tr46": {
@@ -6719,7 +6719,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -6735,9 +6735,9 @@
             "resolved": "https://registry.npmjs.org/transformer-proxy/-/transformer-proxy-0.3.4.tgz",
             "integrity": "sha1-SIX/RphS60Le1NGwZyO7YIfWtCI=",
             "requires": {
-                "promise": "7.3.1",
+                "promise": "^7.0.4",
                 "stream": "0.0.2",
-                "util": "0.10.3"
+                "util": "^0.10.3"
             }
         },
         "tslib": {
@@ -6751,7 +6751,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -6766,7 +6766,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "ua-parser-js": {
@@ -6785,7 +6785,7 @@
             "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9"
+                "debug": "^2.2.0"
             }
         },
         "underscore": {
@@ -6798,8 +6798,8 @@
             "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "requires": {
-                "sprintf-js": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
             }
         },
         "union": {
@@ -6808,7 +6808,7 @@
             "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
             "dev": true,
             "requires": {
-                "qs": "2.3.3"
+                "qs": "~2.3.3"
             },
             "dependencies": {
                 "qs": {
@@ -6825,10 +6825,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6837,7 +6837,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -6846,10 +6846,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -6860,7 +6860,7 @@
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "dev": true,
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "universalify": {
@@ -6879,8 +6879,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -6889,9 +6889,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -6943,16 +6943,16 @@
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "dev": true,
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.4.1",
-                "configstore": "3.1.2",
-                "import-lazy": "2.1.0",
-                "is-ci": "1.1.0",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6961,7 +6961,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -6970,9 +6970,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -6987,7 +6987,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -7010,7 +7010,7 @@
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "use": {
@@ -7019,7 +7019,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7071,8 +7071,8 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "verror": {
@@ -7080,9 +7080,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -7098,7 +7098,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "0.1.2"
+                "browser-process-hrtime": "^0.1.2"
             }
         },
         "webidl-conversions": {
@@ -7136,9 +7136,9 @@
             "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
             }
         },
         "which": {
@@ -7146,7 +7146,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -7160,7 +7160,7 @@
             "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7181,8 +7181,8 @@
                     "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -7191,7 +7191,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -7212,8 +7212,8 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -7228,9 +7228,9 @@
             "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "ws": {
@@ -7239,8 +7239,8 @@
             "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
             "dev": true,
             "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1"
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0"
             }
         },
         "xdg-basedir": {
@@ -7275,18 +7275,18 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
             "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
             "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -7299,8 +7299,8 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -7308,7 +7308,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -7318,7 +7318,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
             "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             }
         },
         "yeast": {


### PR DESCRIPTION
Reported by @SiliconValet; `startPath` was included in verbose route logging, leading to incorrect paths being printed.  This fixes that.