### PR TITLE
skip osx with node 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ os:
 matrix:
     exclude:
         - os: osx # skip this because on Travis, node.js segfaults on osx+node 9
-          node_js:
-            - "9"
-            - "11"
+          node_js: "9"
+        - os: osx # skip this because on Travis, node.js segfaults on osx+node 11
+          node_js: "11"
 cache:
     directories:
         - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ os:
 matrix:
     exclude:
         - os: osx # skip this because on Travis, node.js segfaults on osx+node 9
-          node_js: "9"
+          node_js:
+            - "9"
+            - "11"
 cache:
     directories:
         - node_modules


### PR DESCRIPTION
OSX + Node 11 segfaults at random positions during tests.  This happened a while back with node 9 + osx, so I blacklisted that combo (after testing on a real mac to isolate travis as the root cause).

Same story, new version!