### PR TITLE
don't cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,3 @@ matrix:
     exclude:
         - os: osx # skip this because on Travis, node.js segfaults on osx+node 9
           node_js: "9"
-cache:
-    directories:
-        - node_modules


### PR DESCRIPTION
Skip caching node_modules because `npm ci` deletes it before installing
anyway.  Caching it is a waste of spacetime.