### PR TITLE
Bugfix/esi config with multiple hosts gets baseUrl wrong for all but the first host

### DIFF
--- a/app/esiMiddleware.js
+++ b/app/esiMiddleware.js
@@ -1,7 +1,7 @@
 const _ = require("lodash");
 const ESI = require("nodesi");
 
-function createEsiMiddleware(conf) {
+function buildEsiMap(conf) {
     const esi = _(conf.host)
         .mapValues((host, env) => {
             const esiconfDefaults = {
@@ -15,9 +15,24 @@ function createEsiMiddleware(conf) {
                 cache: false
             };
 
-            return new ESI(_.defaultsDeep(conf.esi, esiconfDefaults));
+            const config = _.defaultsDeep(
+                _.cloneDeep(conf.esi),
+                esiconfDefaults
+            );
+
+            const esi = new ESI(config);
+
+            esi.spandxGeneratedConfig = config;
+
+            return esi;
         })
         .value();
+
+    return esi;
+}
+
+function createEsiMiddleware(conf) {
+    const esi = buildEsiMap(conf);
 
     function applyESI(data, req, res) {
         return new Promise(function(resolve, reject) {
@@ -39,4 +54,4 @@ function createEsiMiddleware(conf) {
     return applyESI;
 }
 
-module.exports = { createEsiMiddleware };
+module.exports = { buildEsiMap, createEsiMiddleware };

--- a/spec/spandx/spandxSpec.js
+++ b/spec/spandx/spandxSpec.js
@@ -225,6 +225,63 @@ describe("spandx", () => {
         });
     });
 
+    describe("spandx.priv.buildEsiMap()", () => {
+        it("should properly set ESI baseUrls when conf.esi is not set", () => {
+            const map = require("../../app/esiMiddleware").buildEsiMap({
+                protocol: "https:",
+                port: 1337,
+                host: {
+                    "ci.foo.redhat.com": "ci.foo.redhat.com",
+                    "qa.foo.redhat.com": "qa.foo.redhat.com",
+                    "stage.foo.redhat.com": "stage.foo.redhat.com",
+                    "prod.foo.redhat.com": "prod.foo.redhat.com"
+                }
+            });
+
+            for (const env of [
+                "ci.foo.redhat.com",
+                "qa.foo.redhat.com",
+                "stage.foo.redhat.com",
+                "prod.foo.redhat.com"
+            ]) {
+                expect(map[env]).toBeDefined();
+                expect(map[env].spandxGeneratedConfig).toBeDefined();
+                expect(map[env].spandxGeneratedConfig.baseUrl).toBeDefined();
+                expect(map[env].spandxGeneratedConfig.baseUrl).toMatch(
+                    `https://${env}:1337`
+                );
+            }
+        });
+
+        it("should properly set ESI baseUrls even when conf.esi is set", () => {
+            const map = require("../../app/esiMiddleware").buildEsiMap({
+                esi: { allowedHosts: [/^https:\/\/access.*.redhat.com$/] },
+                protocol: "https:",
+                port: 1337,
+                host: {
+                    "ci.foo.redhat.com": "ci.foo.redhat.com",
+                    "qa.foo.redhat.com": "qa.foo.redhat.com",
+                    "stage.foo.redhat.com": "stage.foo.redhat.com",
+                    "prod.foo.redhat.com": "prod.foo.redhat.com"
+                }
+            });
+
+            for (const env of [
+                "ci.foo.redhat.com",
+                "qa.foo.redhat.com",
+                "stage.foo.redhat.com",
+                "prod.foo.redhat.com"
+            ]) {
+                expect(map[env]).toBeDefined();
+                expect(map[env].spandxGeneratedConfig).toBeDefined();
+                expect(map[env].spandxGeneratedConfig.baseUrl).toBeDefined();
+                expect(map[env].spandxGeneratedConfig.baseUrl).toMatch(
+                    `https://${env}:1337`
+                );
+            }
+        });
+    });
+
     describe("esi:include", () => {
         describe("when routing to local directories", () => {
             it("should resolve esi:include with absolute paths", async done => {


### PR DESCRIPTION
After restoring ESI (#85), PR #37 wouldn't merge cleanly anymore.  This is a manual merge.  Thanks to @iphands for the changes.