### PR TITLE
Do not use ESI middleware for text streams

### DIFF
--- a/app/spandx.js
+++ b/app/spandx.js
@@ -77,7 +77,13 @@ async function init(confIn) {
     }
 
     if (_.get(conf, "esi")) {
-        app.use(transformerProxy(createEsiMiddleware(conf)));
+        app.use((res, req, next) => {
+            if (res.headers.accept === 'text/event-stream') {
+                next();
+            } else {
+                transformerProxy(createEsiMiddleware(conf))(res, req, next);
+            }
+        });
     }
 
     // dynamically proxy to local filesystem or remote webserver

--- a/app/spandx.js
+++ b/app/spandx.js
@@ -78,10 +78,10 @@ async function init(confIn) {
 
     if (_.get(conf, "esi")) {
         app.use((res, req, next) => {
-            if (res.headers.accept === 'text/event-stream') {
-                next();
-            } else {
+            if (res.headers.accept.includes('text/html') || res.headers.accept.includes('*/*')) {
                 transformerProxy(createEsiMiddleware(conf))(res, req, next);
+            } else {
+                next();
             }
         });
     }


### PR DESCRIPTION
We were trying to include Server side events in our application, but they were silenced by our proxy. I've looked trough the errors and such and found that `transformerProxy` was killing any long requests so we didn't received any data.

This PR simply checks if response header is `text/event-stream` and if so ignore any further middleware enhancements.

It might actually be a bug in `transformerProxy` package, but since that's much further away from our stack I think that this might be better place to fix it.

I guess that @mwcz you are the sole maintaner of this package, if you want me to update this PR somehow let me know!