### PR TITLE
adding the ability to use a proxy server for certain paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Option | Description | Type
 `bs` | A [Browsersync config object][bs-options], in case you need to further customize spandx's Browsersync instance. | object
 `portalChrome` | Settings related to Portal Chrome, see [Portal Chrome settings][portal-chrome-settings]. | object
 `esi` | Set to `true` to enable processing [ESI][esi] tags, or pass in a [nodesi][nodesi] config object. | boolean or object
+`proxy` | Define a proxy host and a URL regex pattern for target URLs that should be proxied. | object
 
 ## Routes
 
@@ -212,6 +213,19 @@ routes: {
 ```
 
 Here, a request to `/my-app/users/active` would be routed to `http://localhost:8080/`.
+
+## Setting up the proxy object
+
+If you're developing an app that needs to connect to a proxy, use the proxy object to define the proxy host and define a URL regex pattern for request that should go through the proxy.
+
+```js
+proxy: {
+    host: "http://someproxy.com:1234",
+    pattern: "^https:\/\/(.*?).someurl.com"
+}
+```
+
+Here, when a URL like `https://api.qa.someurl.com` is requested, it would be routed through the proxy.
 
 ## Overriding Browsersync options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,29 @@
             "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
             "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
         },
+        "agent-base": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+            "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+            "requires": {
+                "debug": "4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
         "ajv": {
             "version": "6.10.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -2597,6 +2620,30 @@
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
             }
         },
         "human-signals": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "finalhandler": "^1.1.1",
         "hostile": "^1.3.2",
         "http-proxy": "^1.17.0",
+        "https-proxy-agent": "^5.0.0",
         "inquirer": "7.0.4",
         "lodash": "^4.17.10",
         "nodesi": "^1.11.0",


### PR DESCRIPTION
Testing instructions
- Add the following to a spandx.config.js file

```
...
proxy: {
  host: "http://squid.corp.redhat.com:3128",
  pattern: "^https:\/\/(.*?).redhat.com"
}
...
```

Anytime a URL goes to the priv.doProxy call in router.js, we'll check to a proxy configuration has been provided. If the target URL is a match for the proxy.pattern that has been passed, then we'll add `agent = new HttpsProxyAgent(confProxy.host)` to the proxy.web call.