### PR TITLE
respond with a 502 when remote is unreachable

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -33,7 +33,7 @@ priv.doProxy = (proxy, req, res, target, confProxy = null) => {
 
         if (confProxy) {
             const regex = RegExp(confProxy.pattern);
-            
+
             // if the target URL passes the regex test based on the
             // pattern provided in the proxy.pattern property,
             // add a new HttpsProxyAgent
@@ -44,7 +44,10 @@ priv.doProxy = (proxy, req, res, target, confProxy = null) => {
 
         proxy.web(req, res, options, e => {
             console.error(e);
-            res.writeHead(200, { "Content-Type": "text/plain" });
+            res.writeHead(502, { "Content-Type": "text/plain" });
+            res.write(
+                `HTTP 502 Bad gateway\n\nRequest to ${req.url} was proxied to ${target} which did not respond.`
+            );
             res.end();
         });
     } else {

--- a/spec/helpers/configs/bad-gateway/spandx.config.js
+++ b/spec/helpers/configs/bad-gateway/spandx.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    host: "localhost",
+    port: 1337,
+    silent: true,
+    routes: {
+        "/": {
+            host: "http://localhost:4014"
+        }
+    }
+};

--- a/spec/spandx/spandxSpec.js
+++ b/spec/spandx/spandxSpec.js
@@ -1010,6 +1010,18 @@ describe("spandx", () => {
                     server.close(done);
                 });
         });
+        it("if the remote is unreachable, return bad gateway", async done => {
+            await spandx.init(
+                "../spec/helpers/configs/bad-gateway/spandx.config.js"
+            );
+            frisby
+                .get("http://localhost:1337/")
+                .expect("status", 502)
+                .expect("bodyContains", /bad gateway/i)
+                .done(() => {
+                    done();
+                });
+        });
     });
 
     describe("routing order", () => {


### PR DESCRIPTION
fixes #145

Instead of returning an empty plaintext 200, remote host failures now return a 502 with a text description of the error.  Tests included.