### PR TITLE
fix: de-dupe URL path logging

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -140,10 +140,11 @@ module.exports = (conf, proxy) => {
             }
 
             if (conf.verbose) {
+                const targetURL = URL.parse(target);
                 console.log(
                     `GET ${c.fg.l.green}${req.url}${c.end} from ${
                         c.fg.l.blue
-                    }${target.replace(new RegExp(`${req.url}$`), "")}${c.end}${
+                    }${`${targetURL.protocol}//${targetURL.host}`}${c.end}${
                         c.fg.l.green
                     }${req.url}${c.end}`
                 );


### PR DESCRIPTION
The previous fix wasn't comprehensive, but this one should be.